### PR TITLE
Change download URL for ACF Pro

### DIFF
--- a/src/Plugins/AcfPro.php
+++ b/src/Plugins/AcfPro.php
@@ -20,7 +20,6 @@ class AcfPro extends AbstractPlugin {
 	public function getDownloadUrl() {
 		$api_query = array(
 			'p' => 'pro',
-			'a' => 'download',
 			'k' => getenv( 'ACF_PRO_KEY' ),
 		);
 
@@ -29,7 +28,7 @@ class AcfPro extends AbstractPlugin {
 			$api_query['t'] = $this->version;
 		}
 
-		$api_url = 'https://connect.advancedcustomfields.com/index.php';
+		$api_url = 'https://connect.advancedcustomfields.com/v2/plugins/download';
 
 		return $api_url . '?' . http_build_query( $api_query, '', '&' );
 	}


### PR DESCRIPTION
This pull request supersedes:

* junaidbhura/composer-wp-pro-plugins#22 by @mcaskill
* junaidbhura/composer-wp-pro-plugins#70 by @Spidlace

## Checklist:

* [x] I've read the [Contributing page](https://github.com/mcaskill/composer-wp-pro-plugins/blob/main/CONTRIBUTING.md).
* [x] Spidlace created an issue: junaidbhura/composer-wp-pro-plugins#71
* [x] My code is tested.
* [x] My code follows the WordPress code style.
* [x] My code has proper inline documentation.

## Description

The current API URI, `?p=pro&a=download&k=%ACF_PRO_KEY%&t=%version%`, has recently been abandoned in favour of: `/v2/plugins/download?p=pro&k=%ACF_PRO_KEY%&t=%version%`.

## How has this been tested?

Independently tested by @Spidlace and I.