### PR TITLE
Fail if we download the incorrect version of Gravity Forms

### DIFF
--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Composer\Semver\Semver;
 use Exception;
 use Junaidbhura\Composer\WPProPlugins\Http;
 use UnexpectedValueException;
@@ -106,6 +107,22 @@ class GravityForms extends AbstractPlugin {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL for package %s',
 				$this->getPackageName()
+			) );
+		}
+
+		if ( empty( $data['version_latest'] ) || ! is_scalar( $data['version_latest'] ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a valid download version number for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
+
+		if ( ! Semver::satisfies( $data['version_latest'], $this->version ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected download version (%s) to match installed version (%s) of package %s',
+				$data['version_latest'],
+				$this->version,
+				'junaidbhura/' . $this->slug
 			) );
 		}
 

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -103,30 +103,66 @@ class GravityForms extends AbstractPlugin {
 			throw new UnexpectedValueException( $message );
 		}
 
-		if ( empty( $data['download_url_latest'] ) || ! is_string( $data['download_url_latest'] ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a valid download URL for package %s',
-				$this->getPackageName()
-			) );
+		$candidates = array(
+			array( 'version', 'download_url' ),
+			array( 'version_latest', 'download_url_latest' ),
+		);
+		foreach ( $candidates as $candidate ) {
+			list( $version_key, $download_key ) = $candidate;
+
+			try {
+				return $this->findDownloadUrl( $data, $version_key, $download_key );
+			} catch ( UnexpectedValueException $e ) {
+				// throw the last exception after the loop
+			}
 		}
 
-		if ( empty( $data['version_latest'] ) || ! is_scalar( $data['version_latest'] ) ) {
+		throw $e;
+	}
+
+	/**
+	 * @param  array<string, mixed> $response     The EDD API response.
+	 * @param  string               $version_key  The API field key that holds the version.
+	 * @param  string               $download_key The API field key that holds the download URL.
+	 * @throws UnexpectedValueException If the response is not OK, invalid, or malformed.
+	 * @return string
+	 */
+	protected function findDownloadUrl( array $response, $version_key, $download_key ) {
+		$version      = array_key_exists( $version_key, $response ) ? $response[ $version_key ] : null;
+		$download_url = array_key_exists( $download_key, $response ) ? $response[ $download_key ] : null;
+
+		if ( false === $version ) {
+			// If FALSE, the package does not exist / is not available
 			throw new UnexpectedValueException( sprintf(
-				'Expected a valid download version number for package %s',
+				'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 				'junaidbhura/' . $this->slug
 			) );
 		}
 
-		if ( ! Semver::satisfies( $data['version_latest'], $this->version ) ) {
+		if ( empty( $download_url ) || ! is_string( $download_url ) ) {
 			throw new UnexpectedValueException( sprintf(
-				'Expected download version (%s) to match installed version (%s) of package %s',
-				$data['version_latest'],
+				'Expected a valid download URL from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
+
+		if ( empty( $version ) || ! is_scalar( $version ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a valid download version number from API for package %s.',
+				'junaidbhura/' . $this->slug
+			) );
+		}
+
+		if ( ! Semver::satisfies( $version, $this->version ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected download version from API (%s) to match installed version (%s) of package %s.',
+				$version,
 				$this->version,
 				'junaidbhura/' . $this->slug
 			) );
 		}
 
-		return str_replace( 'http://', 'https://', $data['download_url_latest'] );
+		return str_replace( 'http://', 'https://', $download_url );
 	}
 
 }


### PR DESCRIPTION
This pull request supersedes:

* junaidbhura/composer-wp-pro-plugins#60

## Checklist

- [x] I've read the [Contributing page](https://github.com/mcaskill/composer-wp-pro-plugins/blob/main/CONTRIBUTING.md).
- [x] No issue.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Follow-up to junaidbhura/composer-wp-pro-plugins#47 and fork of junaidbhura/composer-wp-pro-plugins#58.

Depends on mcaskill/composer-wp-pro-plugins#2 being merged first.

Use Semver to check main and latest versions.

Prioritize main version (`download_url`) over latest version (`download_url_latest`) since most people will only specify `MAJOR.MINOR.PATCH` as opposed to Gravity Forms `MAJOR.MINOR.PATCH.HOTFIX`. This also prevents "contamination" of a cache key for a "main version" with the contents of the "latest version".

Improved `GravityForms` to check if download version matches the package's version with support for either available download: the "main version" (`download_url`) or the "latest version" (`download_url_latest`). For example:

* `version` (main): `2.7.2` (`MAJOR.MINOR.PATCH`)
* `version_latest`: `2.7.2.1` (`MAJOR.MINOR.PATCH.HOTFIX`)

By checking both and distinguishing between them, this prevents "contamination" of cache key for a "main version" with the contents of the "latest version".

For example, currently if a project requires Gravity Forms 2.7.2 (which is used as the cache key):

* User A installs the project and the Composer plugin downloads 2.7.2.1.
* User B installs the project the next day and the Composer plugin downloads 2.7.2.2.

Now you have two users with differing versions but using the same cache key.

## How has this been tested?

I'm testing this on a client project that uses Gravity Forms.